### PR TITLE
Change Update point tests

### DIFF
--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -68,9 +68,9 @@ bool XPT2046_Touchscreen::bufferEmpty()
 	return ((millis() - msraw) < MSEC_THRESHOLD);
 }
 
-static int32_t besttwoavg( int32_t x , int32_t y , int32_t z ) {
-  int32_t da, db, dc;
-  int32_t reta = 0;
+static int16_t besttwoavg( int16_t x , int16_t y , int16_t z ) {
+  int16_t da, db, dc;
+  int16_t reta = 0;
   if ( x > y ) da = x - y; else da = y - x;
   if ( x > z ) db = x - z; else db = z - x;
   if ( z > y ) dc = z - y; else dc = y - z;

--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -105,6 +105,7 @@ void XPT2046_Touchscreen::update()
 		data[2] = SPI.transfer16(0xD1 /* Y */) >> 3;
 		data[3] = SPI.transfer16(0x91 /* X */) >> 3;
 	}
+	else data[0] = data[1] = data[2] = data[3] = 0;	// Compiler warns these values may be used unset on early exit.
 	data[4] = SPI.transfer16(0xD0 /* Y */) >> 3;	// Last Y touch power down
 	data[5] = SPI.transfer16(0) >> 3;
 	digitalWrite(csPin, HIGH);
@@ -133,5 +134,6 @@ void XPT2046_Touchscreen::update()
 		yraw = y;
 	}
 }
+
 
 

--- a/examples/ILI9341Test/ILI9341Test.ino
+++ b/examples/ILI9341Test/ILI9341Test.ino
@@ -12,10 +12,12 @@ XPT2046_Touchscreen ts(CS_PIN);
 ILI9341_t3 tft = ILI9341_t3(TFT_CS, TFT_DC);
 
 void setup() {
+  Serial.begin(38400);
   tft.begin();
   tft.setRotation(1);
   tft.fillScreen(ILI9341_BLACK);
   ts.begin();
+  while (!Serial && (millis() <= 1000));
 }
 
 boolean wastouched = true;

--- a/examples/TouchTest/TouchTest.ino
+++ b/examples/TouchTest/TouchTest.ino
@@ -7,7 +7,9 @@
 XPT2046_Touchscreen ts(CS_PIN);
 
 void setup() {
+  Serial.begin(38400);
   ts.begin();
+  while (!Serial && (millis() <= 1000));
 }
 
 void loop() {


### PR DESCRIPTION
: Set msraw only when storing valid data, that delays next read
: Truncate SPI when first X==0 indicates no touch
: calc best 2 of 3 readings for X and Y independently

<edit> just noticed besttwoavg() is all int32_t and needs only int16_t