### PR TITLE
Please review these changes for inclusion

### DIFF
--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -45,19 +45,19 @@ bool XPT2046_Touchscreen::begin()
 
 TS_Point XPT2046_Touchscreen::getPoint()
 {
-	update( true );
+	update();
 	return TS_Point(xraw, yraw, zraw);
 }
 
 bool XPT2046_Touchscreen::touched()
 {
-	update( false );
+	update();
 	return (zraw >= Z_THRESHOLD);
 }
 
 void XPT2046_Touchscreen::readData(uint16_t *x, uint16_t *y, uint8_t *z)
 {
-	update( true );
+	update();
 	*x = xraw;
 	*y = yraw;
 	*z = zraw;
@@ -85,7 +85,7 @@ static int16_t besttwoavg( int16_t x , int16_t y , int16_t z ) {
 // TODO: perhaps a future version should offer an option for more oversampling,
 //       with the RANSAC algorithm https://en.wikipedia.org/wiki/RANSAC
 
-void XPT2046_Touchscreen::update( boolean getpoint )
+void XPT2046_Touchscreen::update()
 {
 	int16_t data[6];
 
@@ -98,7 +98,7 @@ void XPT2046_Touchscreen::update( boolean getpoint )
 	int z = z1 + 4095;
 	int16_t z2 = SPI.transfer16(0x91 /* X */) >> 3;
 	z -= z2;
-	if (z >= Z_THRESHOLD && getpoint) {
+	if (z >= Z_THRESHOLD) {
 		SPI.transfer16(0x91 /* X */);  // dummy X measure, 1st is always noisy
 		data[0] = SPI.transfer16(0xD1 /* Y */) >> 3;
 		data[1] = SPI.transfer16(0x91 /* X */) >> 3; // make 3 x-y measurements
@@ -118,8 +118,7 @@ void XPT2046_Touchscreen::update( boolean getpoint )
 		return;
 	}
 	zraw = z;
-	if (!getpoint)
-		return;
+	
 	// Average pair with least distance between each measured x then y
 	//Serial.printf("    z1=%d,z2=%d  ", z1, z2);
 	//Serial.printf("p=%d,  %d,%d  %d,%d  %d,%d", zraw,

--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -45,19 +45,19 @@ bool XPT2046_Touchscreen::begin()
 
 TS_Point XPT2046_Touchscreen::getPoint()
 {
-	update();
+	update( true );
 	return TS_Point(xraw, yraw, zraw);
 }
 
 bool XPT2046_Touchscreen::touched()
 {
-	update();
+	update( false );
 	return (zraw >= Z_THRESHOLD);
 }
 
 void XPT2046_Touchscreen::readData(uint16_t *x, uint16_t *y, uint8_t *z)
 {
-	update();
+	update( true );
 	*x = xraw;
 	*y = yraw;
 	*z = zraw;
@@ -85,7 +85,7 @@ static int16_t besttwoavg( int16_t x , int16_t y , int16_t z ) {
 // TODO: perhaps a future version should offer an option for more oversampling,
 //       with the RANSAC algorithm https://en.wikipedia.org/wiki/RANSAC
 
-void XPT2046_Touchscreen::update()
+void XPT2046_Touchscreen::update( boolean getpoint )
 {
 	int16_t data[6];
 
@@ -98,7 +98,7 @@ void XPT2046_Touchscreen::update()
 	int z = z1 + 4095;
 	int16_t z2 = SPI.transfer16(0x91 /* X */) >> 3;
 	z -= z2;
-	if (z >= Z_THRESHOLD) {
+	if (z >= Z_THRESHOLD && getpoint) {
 		SPI.transfer16(0x91 /* X */);  // dummy X measure, 1st is always noisy
 		data[0] = SPI.transfer16(0xD1 /* Y */) >> 3;
 		data[1] = SPI.transfer16(0x91 /* X */) >> 3; // make 3 x-y measurements
@@ -118,7 +118,8 @@ void XPT2046_Touchscreen::update()
 		return;
 	}
 	zraw = z;
-	
+	if (!getpoint)
+		return;
 	// Average pair with least distance between each measured x then y
 	//Serial.printf("    z1=%d,z2=%d  ", z1, z2);
 	//Serial.printf("p=%d,  %d,%d  %d,%d  %d,%d", zraw,

--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -41,17 +41,19 @@ public:
 
 class XPT2046_Touchscreen {
 public:
-	XPT2046_Touchscreen(uint8_t cspin);
+	XPT2046_Touchscreen(uint8_t cspin, uint8_t tirq=255);
 	bool begin();
 	TS_Point getPoint();
 	bool touched();
 	void readData(uint16_t *x, uint16_t *y, uint8_t *z);
 	bool bufferEmpty();
 	uint8_t bufferSize() { return 1; }
+// protected:
+	bool isrWake;
 
 private:
 	void update();
-	uint8_t csPin;
+	uint8_t csPin, tirqPin;
 	int16_t xraw, yraw, zraw;
 	uint32_t msraw;
 };

--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -50,7 +50,7 @@ public:
 	uint8_t bufferSize() { return 1; }
 
 private:
-	void update(boolean getpoint);
+	void update();
 	uint8_t csPin;
 	int16_t xraw, yraw, zraw;
 	uint32_t msraw;

--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -50,7 +50,7 @@ public:
 	uint8_t bufferSize() { return 1; }
 
 private:
-	void update();
+	void update(boolean getpoint);
 	uint8_t csPin;
 	int16_t xraw, yraw, zraw;
 	uint32_t msraw;

--- a/examples/ILI9341Test/ILI9341Test.ino
+++ b/examples/ILI9341Test/ILI9341Test.ino
@@ -9,6 +9,11 @@
 // MOSI=11, MISO=12, SCK=13
 
 XPT2046_Touchscreen ts(CS_PIN);
+#define TIRQ_PIN  2
+//XPT2046_Touchscreen ts(CS_PIN);  // Param 2 - NULL - No interrupts
+//XPT2046_Touchscreen ts(CS_PIN, 255);  // Param 2 - 255 - No interrupts
+//XPT2046_Touchscreen ts(CS_PIN, TIRQ_PIN);  // Param 2 - Touch IRQ Pin - interrupt enabled polling
+
 ILI9341_t3 tft = ILI9341_t3(TFT_CS, TFT_DC);
 
 void setup() {

--- a/examples/TouchTest/TouchTest.ino
+++ b/examples/TouchTest/TouchTest.ino
@@ -4,7 +4,11 @@
 #define CS_PIN  8
 // MOSI=11, MISO=12, SCK=13
 
-XPT2046_Touchscreen ts(CS_PIN);
+//XPT2046_Touchscreen ts(CS_PIN);
+#define TIRQ_PIN  2
+//XPT2046_Touchscreen ts(CS_PIN);  // Param 2 - NULL - No interrupts
+//XPT2046_Touchscreen ts(CS_PIN, 255);  // Param 2 - 255 - No interrupts
+XPT2046_Touchscreen ts(CS_PIN, TIRQ_PIN);  // Param 2 - Touch IRQ Pin - interrupt enabled polling
 
 void setup() {
   Serial.begin(38400);
@@ -12,7 +16,7 @@ void setup() {
   while (!Serial && (millis() <= 1000));
 }
 
-void loop() {
+void loopB() {
   TS_Point p = ts.getPoint();
   Serial.print("Pressure = ");
   Serial.print(p.z);
@@ -23,5 +27,21 @@ void loop() {
     Serial.print(p.y);
   }
   Serial.println();
-  delay(100);
+  //  delay(100);
+  delay(30);
 }
+
+void loop() {
+  if (ts.touched()) {
+    TS_Point p = ts.getPoint();
+    Serial.print("Pressure = ");
+    Serial.print(p.z);
+    Serial.print(", x = ");
+    Serial.print(p.x);
+    Serial.print(", y = ");
+    Serial.print(p.y);
+    delay(30);
+    Serial.println();
+  }
+}
+


### PR DESCRIPTION
Small change of 20 lines uses interrupt pin to gate the actual touch reading.

I tried to fit it into the PJRC code model - there is one exposed value that would allow user code to disable touch reading (until next interrupt if enabled)

Putting the CPP class code as an ISR was done based on FrankB's personal usage.

On interrupt only a BOOLEAN flag is set.

Doing anything more complex enters the realm of race condition cascading interrupts.

The boolean goes false AFTER the prior SPI read is detects NO_TOUCH, which will have triggered the interrupt in the process.  DIsabling it then will set it false, preventing added SPI reads of touch until the interrupt falls again.

I have tested this to work with T_3.1 and T_LC.  LC works on TouchTest, I also tested on a complex graphics button example with LC and AdaFruit driver.