### PR TITLE
Added orientation parameter to the constructor to allow switching coords

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ without hardware access when no interrupt was recorded.
     #define TIRQ_PIN  2
     XPT2046_Touchscreen ts(CS_PIN, TIRQ_PIN);
 
+A third constructor parameter allows you to modify the orientation of the
+default coordinate system. It consists of three flags: XPT2046_SWITCH_XY,
+XPT2046_FLIP_X, XPT2046_FLIP_Y. If you don't want to use an interrupt pin,
+you need to disable that by passing XPT2046_NO_IRQ as the second parameter.
+For example, the following constructor makes the cheap TJCTMP24024 board
+produce coordinates comparable to the Arduino STMPE610 touchscreens,
+so you can use the example code just by redefining the touchscreen:
+
+    XPT2046_Touchscreen ts(CS_PIN, XPT2046_NO_IRQ, XPT2046_SWITCH_XY | XPT2046_FLIP_Y);
+
 In setup(), use the begin function to initialize the touchscreen
 
       ts.begin();

--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -39,9 +39,13 @@ public:
 	int16_t x, y, z;
 };
 
+#define	XPT2046_NO_IRQ	255
+#define XPT2046_SWITCH_XY	0x1
+#define XPT2046_FLIP_X		0x2
+#define XPT2046_FLIP_Y		0x4
 class XPT2046_Touchscreen {
 public:
-	XPT2046_Touchscreen(uint8_t cspin, uint8_t tirq=255);
+	XPT2046_Touchscreen(uint8_t cspin, uint8_t tirq=XPT2046_NO_IRQ, uint8_t orientation = 0);
 	bool begin();
 	TS_Point getPoint();
 	bool touched();
@@ -54,6 +58,7 @@ public:
 private:
 	void update();
 	uint8_t csPin, tirqPin;
+	uint8_t orientation;
 	int16_t xraw, yraw, zraw;
 	uint32_t msraw;
 };


### PR DESCRIPTION
This allows use of standard Arduino example programs on boards that have the touchscreen oriented differently. Please take a look at the diffs.