### PR TITLE
Added calibration to match the Pixels on screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ libraries.
       ts.begin();
       ts.setRotation(1);
 
+Optionally you can also use a calibration (you can read more about calibration down below) to match the Pixels on your Screen. In the setup() ether use the calibration saved in the EEPROM:
+
+      ts.begin(displayWidth, displayHeight, getEEPROMCalibration());
+      
+Or just type in your own calibration data (read down below how to get them):
+
+      ts.begin(displayWidth, displayHeight, TS_Calibration(vi1, vj1, vi2, vj2);
+
+To get the width and heigth of the screen with a Adafruit GFX library compatible screen (or with the ILI9341_t3 library) you can use these commands:
+
+      ILI9341_t3 display = ILI9341_t3(TFT_CS, TFT_DC, TFT_RST);
+      ts.begin(display.width(), display.height(), getEEPROMCalibration());
+      
 ## Reading Touch Info
 
 The touched() function tells if the display is currently being touched,
@@ -51,7 +64,21 @@ or with getPoint(), which returns a TS_Point object:
       Serial.print(", y = ");
       Serial.print(p.y);
 
+or with a calibration, to match the pixels on your screen (you have to set a calibration like shown above to use calibration, you also have to calibrate the display like shown down below):
+
+      TS_Point p = ts.getPixel();
+      Serial.print("calibrated x = ");
+      Serial.print(p.x);
+      Serial.print(", calibrated y = ");
+      Serial.print(p.y);
+
 The Z coordinate represents the amount of pressure applied to the screen.
+
+## Calibration
+
+To calibrate the Touchscreen, use the example scetch called "Calibration". Its ment to be used with the ILI9341_t3 library by Paul Stoffregen (but you can easily modify it to match your display using the Adafruit GFX library). To calibrate the display, load the scetch on your Arduino or Teensy (Change the pin definitions if they don't match with your setup) and tap the first, than the second + on the Screen. After all, you will see the calibration data in the following order for 3 seconds: vi1, vj1, vi2, vj2. The calibration is automatically saved in the EEPROM that you can use it easier the next time with a different scetch. After it saved the calibration to EEPROM and then after 3 seconds, you can draw something on the screen to test the calibration. If your drawing doesn't really match up with your actual touch-point, just redo the calibration process.
+
+What is EEPROM? The eeprom is a non-volitale storage in the Arduino/Teensy to save small amounts of data even if the Arduino is turned off. So it is great to save one or more calibration data in it to reuse it next time you power up the Arduino, or to use it with a different scetch.
 
 ## Adafruit Library Compatibility
 

--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -1,24 +1,24 @@
 /* Touchscreen library for XPT2046 Touch Controller Chip
- * Copyright (c) 2015, Paul Stoffregen, paul@pjrc.com
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice, development funding notice, and this permission
- * notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+   Copyright (c) 2015, Paul Stoffregen, paul@pjrc.com
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice, development funding notice, and this permission
+   notice shall be included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
 
 #include "XPT2046_Touchscreen.h"
 
@@ -30,53 +30,66 @@
 static XPT2046_Touchscreen 	*isrPinptr;
 void isrPin(void);
 
-bool XPT2046_Touchscreen::begin()
+bool XPT2046_Touchscreen::begin(uint16_t width, uint16_t height, TS_Calibration cal)
 {
-	SPI.begin();
-	pinMode(csPin, OUTPUT);
-	digitalWrite(csPin, HIGH);
-	if (255 != tirqPin) {
-		pinMode( tirqPin, INPUT );
-		attachInterrupt(digitalPinToInterrupt(tirqPin), isrPin, FALLING);
-		isrPinptr = this;
-	}
-	return true;
+  SPI.begin();
+  pinMode(csPin, OUTPUT);
+  digitalWrite(csPin, HIGH);
+  if (255 != tirqPin) {
+    pinMode( tirqPin, INPUT );
+    attachInterrupt(digitalPinToInterrupt(tirqPin), isrPin, FALLING);
+    isrPinptr = this;
+  }
+
+  _width = width;
+  _height = height;
+
+  this->setCalibration(cal);
+  return true;
 }
 
 void isrPin( void )
 {
-	XPT2046_Touchscreen *o = isrPinptr;
-	o->isrWake = true;
+  XPT2046_Touchscreen *o = isrPinptr;
+  o->isrWake = true;
 }
 
 TS_Point XPT2046_Touchscreen::getPoint()
 {
-	update();
-	return TS_Point(xraw, yraw, zraw);
+  update();
+
+  uint16_t x = xraw, y = yraw;
+
+  this->rotate(x, y);
+
+  return TS_Point(x, y, zraw);
 }
 
 bool XPT2046_Touchscreen::tirqTouched()
 {
-	return (isrWake);
+  return (isrWake);
 }
 
 bool XPT2046_Touchscreen::touched()
 {
-	update();
-	return (zraw >= Z_THRESHOLD);
+  update();
+  return (zraw >= Z_THRESHOLD);
 }
 
 void XPT2046_Touchscreen::readData(uint16_t *x, uint16_t *y, uint8_t *z)
 {
-	update();
-	*x = xraw;
-	*y = yraw;
-	*z = zraw;
+  update();
+
+  *x = xraw;
+  *y = yraw;
+  *z = zraw;
+
+  this->rotate(*x, *y);
 }
 
 bool XPT2046_Touchscreen::bufferEmpty()
 {
-	return ((millis() - msraw) < MSEC_THRESHOLD);
+  return ((millis() - msraw) < MSEC_THRESHOLD);
 }
 
 static int16_t besttwoavg( int16_t x , int16_t y , int16_t z ) {
@@ -98,73 +111,121 @@ static int16_t besttwoavg( int16_t x , int16_t y , int16_t z ) {
 
 void XPT2046_Touchscreen::update()
 {
-	int16_t data[6];
+  int16_t data[6];
 
-	if (!isrWake) return;
-	uint32_t now = millis();
-	if (now - msraw < MSEC_THRESHOLD) return;
-	
-	SPI.beginTransaction(SPI_SETTING);
-	digitalWrite(csPin, LOW);
-	SPI.transfer(0xB1 /* Z1 */);
-	int16_t z1 = SPI.transfer16(0xC1 /* Z2 */) >> 3;
-	int z = z1 + 4095;
-	int16_t z2 = SPI.transfer16(0x91 /* X */) >> 3;
-	z -= z2;
-	if (z >= Z_THRESHOLD) {
-		SPI.transfer16(0x91 /* X */);  // dummy X measure, 1st is always noisy
-		data[0] = SPI.transfer16(0xD1 /* Y */) >> 3;
-		data[1] = SPI.transfer16(0x91 /* X */) >> 3; // make 3 x-y measurements
-		data[2] = SPI.transfer16(0xD1 /* Y */) >> 3;
-		data[3] = SPI.transfer16(0x91 /* X */) >> 3;
-	}
-	else data[0] = data[1] = data[2] = data[3] = 0;	// Compiler warns these values may be used unset on early exit.
-	data[4] = SPI.transfer16(0xD0 /* Y */) >> 3;	// Last Y touch power down
-	data[5] = SPI.transfer16(0) >> 3;
-	digitalWrite(csPin, HIGH);
-	SPI.endTransaction();
-	//Serial.printf("z=%d  ::  z1=%d,  z2=%d  ", z, z1, z2);
-	if (z < 0) z = 0;
-	if (z < Z_THRESHOLD) { //	if ( !touched ) {
-		// Serial.println();
-		zraw = 0;
-		if (z < Z_THRESHOLD_INT) { //	if ( !touched ) {
-			if (255 != tirqPin) isrWake = false;
-		}
-		return;
-	}
-	zraw = z;
-	
-	// Average pair with least distance between each measured x then y
-	//Serial.printf("    z1=%d,z2=%d  ", z1, z2);
-	//Serial.printf("p=%d,  %d,%d  %d,%d  %d,%d", zraw,
-		//data[0], data[1], data[2], data[3], data[4], data[5]);
-	int16_t x = besttwoavg( data[0], data[2], data[4] );
-	int16_t y = besttwoavg( data[1], data[3], data[5] );
-	
-	//Serial.printf("    %d,%d", x, y);
-	//Serial.println();
-	if (z >= Z_THRESHOLD) {
-		msraw = now;	// good read completed, set wait
-		switch (rotation) {
-		  case 0:
-			xraw = 4095 - y;
-			yraw = x;
-			break;
-		  case 1:
-			xraw = x;
-			yraw = y;
-			break;
-		  case 2:
-			xraw = y;
-			yraw = 4095 - x;
-			break;
-		  default: // 3
-			xraw = 4095 - x;
-			yraw = 4095 - y;
-		}
-	}
+  if (!isrWake) return;
+  uint32_t now = millis();
+  if (now - msraw < MSEC_THRESHOLD) return;
+
+  SPI.beginTransaction(SPI_SETTING);
+  digitalWrite(csPin, LOW);
+  SPI.transfer(0xB1 /* Z1 */);
+  int16_t z1 = SPI.transfer16(0xC1 /* Z2 */) >> 3;
+  int z = z1 + 4095;
+  int16_t z2 = SPI.transfer16(0x91 /* X */) >> 3;
+  z -= z2;
+  if (z >= Z_THRESHOLD) {
+    SPI.transfer16(0x91 /* X */);  // dummy X measure, 1st is always noisy
+    data[0] = SPI.transfer16(0xD1 /* Y */) >> 3;
+    data[1] = SPI.transfer16(0x91 /* X */) >> 3; // make 3 x-y measurements
+    data[2] = SPI.transfer16(0xD1 /* Y */) >> 3;
+    data[3] = SPI.transfer16(0x91 /* X */) >> 3;
+  }
+  else data[0] = data[1] = data[2] = data[3] = 0;	// Compiler warns these values may be used unset on early exit.
+  data[4] = SPI.transfer16(0xD0 /* Y */) >> 3;	// Last Y touch power down
+  data[5] = SPI.transfer16(0) >> 3;
+  digitalWrite(csPin, HIGH);
+  SPI.endTransaction();
+  //Serial.printf("z=%d  ::  z1=%d,  z2=%d  ", z, z1, z2);
+  if (z < 0) z = 0;
+  if (z < Z_THRESHOLD) { //	if ( !touched ) {
+    // Serial.println();
+    zraw = 0;
+    if (z < Z_THRESHOLD_INT) { //	if ( !touched ) {
+      if (255 != tirqPin) isrWake = false;
+    }
+    return;
+  }
+  zraw = z;
+
+  // Average pair with least distance between each measured x then y
+  //Serial.printf("    z1=%d,z2=%d  ", z1, z2);
+  //Serial.printf("p=%d,  %d,%d  %d,%d  %d,%d", zraw,
+  //data[0], data[1], data[2], data[3], data[4], data[5]);
+  int16_t x = besttwoavg( data[0], data[2], data[4] );
+  int16_t y = besttwoavg( data[1], data[3], data[5] );
+
+  //Serial.printf("    %d,%d", x, y);
+  //Serial.println();
+  if (z >= Z_THRESHOLD) {
+    msraw = now;	// good read completed, set wait
+    xraw = x;
+    yraw = y;
+  }
 }
 
+TS_Point XPT2046_Touchscreen::getPixel() {
+  update();
+  
+#if defined(SWAP_AXES) && SWAP_AXES
+  uint16_t xPixel = (uint16_t)(_cal_dx * (yraw - _cal_vj1) / _cal_dvj + CAL_OFFSET);
+  uint16_t yPixel = (uint16_t)(_cal_dy * (xraw - _cal_vi1) / _cal_dvi + CAL_OFFSET);
+#else
+  uint16_t xPixel = (uint16_t)(_cal_dx * (xraw - _cal_vi1) / _cal_dvi + CAL_OFFSET);
+  uint16_t yPixel = (uint16_t)(_cal_dy * (yraw - _cal_vj1) / _cal_dvj + CAL_OFFSET);
+#endif
+  
+  this->rotate(xPixel, yPixel);
 
+  return TS_Point(xPixel, yPixel, zraw);
+}
+
+void XPT2046_Touchscreen::getCalibrationPoints(uint16_t &x1, uint16_t &y1, uint16_t &x2, uint16_t &y2) {
+  x1 = y1 = CAL_OFFSET;
+  x2 = _width - CAL_OFFSET;
+  y2 = _height - CAL_OFFSET;
+}
+
+void XPT2046_Touchscreen::setCalibration (TS_Calibration cal) {
+  _cal_dx = _width - 2 * CAL_OFFSET;
+  _cal_dy = _height - 2 * CAL_OFFSET;
+
+  _cal_vi1 = (int32_t)cal.vi1;
+  _cal_vj1 = (int32_t)cal.vj1;
+  _cal_dvi = (int32_t)cal.vi2 - cal.vi1;
+  _cal_dvj = (int32_t)cal.vj2 - cal.vj1;
+}
+
+void XPT2046_Touchscreen::saveCalibrationToEEPROM(TS_Calibration &cal, unsigned int eepromSlot){
+  eepromSlot = eepromSlot * sizeof(cal);
+  
+  EEPROM.put(eepromSlot, cal);
+}
+
+TS_Calibration XPT2046_Touchscreen::getEEPROMCalibration(unsigned int eepromSlot){
+  eepromSlot = eepromSlot * sizeof(TS_Calibration);
+  TS_Calibration cal;
+
+  EEPROM.get(eepromSlot, cal);
+
+  return cal;
+}
+
+void XPT2046_Touchscreen::rotate(uint16_t &x, uint16_t &y){
+  switch (rotation) {
+    case 0:
+      x = 4095 - y;
+      y = x;
+      break;
+    case 1:
+      break;
+    case 2:
+      x = y;
+      y = 4095 - x;
+      break;
+    default: // 3
+      x = 4095 - x;
+      y = 4095 - y;
+  }
+}
 

--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -58,7 +58,7 @@ TS_Point XPT2046_Touchscreen::getPoint()
 {
   update();
 
-  uint16_t x = xraw, y = yraw;
+  int16_t x = xraw, y = yraw;
 
   this->rotateRaw(x, y);
 
@@ -80,11 +80,12 @@ void XPT2046_Touchscreen::readData(uint16_t *x, uint16_t *y, uint8_t *z)
 {
   update();
 
-  *x = xraw;
-  *y = yraw;
+  int16_t tempX = xraw, tempY = yraw;
+  rotateRaw(tempX, tempY);
+  
+  *x = tempX;
+  *y = tempY;
   *z = zraw;
-
-  this->rotateRaw(*x, *y);
 }
 
 bool XPT2046_Touchscreen::bufferEmpty()
@@ -190,8 +191,8 @@ void XPT2046_Touchscreen::setCalibration (TS_Calibration cal) {
   _cal_dx = _width - 2 * CAL_OFFSET;
   _cal_dy = _height - 2 * CAL_OFFSET;
 
-  _cal_vi1 = (int32_t)cal.vi1;
-  _cal_vj1 = (int32_t)cal.vj1;
+  _cal_vi1 = cal.vi1;
+  _cal_vj1 = cal.vj1;
   _cal_dvi = (int32_t)cal.vi2 - cal.vi1;
   _cal_dvj = (int32_t)cal.vj2 - cal.vj1;
 }
@@ -211,8 +212,8 @@ TS_Calibration XPT2046_Touchscreen::getEEPROMCalibration(unsigned int eepromSlot
   return cal;
 }
 
-void XPT2046_Touchscreen::rotateRaw(uint16_t &x, uint16_t &y){
-  uint16_t tempX = x, tempY = y;
+void XPT2046_Touchscreen::rotateRaw(int16_t &x, int16_t &y){
+  int16_t tempX = x, tempY = y;
   
   switch (rotation) {
     case 0:

--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -60,7 +60,7 @@ TS_Point XPT2046_Touchscreen::getPoint()
 
   uint16_t x = xraw, y = yraw;
 
-  this->rotate(x, y);
+  this->rotateRaw(x, y);
 
   return TS_Point(x, y, zraw);
 }
@@ -84,7 +84,7 @@ void XPT2046_Touchscreen::readData(uint16_t *x, uint16_t *y, uint8_t *z)
   *y = yraw;
   *z = zraw;
 
-  this->rotate(*x, *y);
+  this->rotateRaw(*x, *y);
 }
 
 bool XPT2046_Touchscreen::bufferEmpty()
@@ -175,7 +175,7 @@ TS_Point XPT2046_Touchscreen::getPixel() {
   uint16_t yPixel = (uint16_t)(_cal_dy * (yraw - _cal_vj1) / _cal_dvj + CAL_OFFSET);
 #endif
   
-  this->rotate(xPixel, yPixel);
+  this->rotateCal(xPixel, yPixel);
 
   return TS_Point(xPixel, yPixel, zraw);
 }
@@ -211,21 +211,42 @@ TS_Calibration XPT2046_Touchscreen::getEEPROMCalibration(unsigned int eepromSlot
   return cal;
 }
 
-void XPT2046_Touchscreen::rotate(uint16_t &x, uint16_t &y){
+void XPT2046_Touchscreen::rotateRaw(uint16_t &x, uint16_t &y){
+  uint16_t tempX = x, tempY = y;
+  
   switch (rotation) {
     case 0:
-      x = 4095 - y;
-      y = x;
+      x = 4095 - tempY;
+      y = tempX;
       break;
     case 1:
       break;
     case 2:
-      x = y;
-      y = 4095 - x;
+      x = tempY;
+      y = 4095 - tempX;
       break;
     default: // 3
-      x = 4095 - x;
-      y = 4095 - y;
+      x = 4095 - tempX;
+      y = 4095 - tempY;
   }
 }
 
+void XPT2046_Touchscreen::rotateCal(uint16_t &x, uint16_t &y){
+  uint16_t tempX = x, tempY = y;
+  
+  switch (rotation) {
+    case 0:
+      x = _height - tempY;
+      y = tempX;
+      break;
+    case 1:
+      break;
+    case 2:
+      x = tempY;
+      y = _width - tempX;
+      break;
+    default: // 3
+      x = _width - tempX;
+      y = _height - tempY;
+  }
+}

--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -101,7 +101,8 @@ class XPT2046_Touchscreen {
 
   private:
     void update();
-    void rotate(uint16_t &x, uint16_t &y);
+    void rotateRaw(uint16_t &x, uint16_t &y);
+    void rotateCal(uint16_t &x, uint16_t &y);
     
     uint8_t csPin, tirqPin, rotation = 1;
     int16_t xraw = 0, yraw = 0, zraw = 0, _width = 0, _height = 0;

--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -101,11 +101,12 @@ class XPT2046_Touchscreen {
 
   private:
     void update();
-    void rotateRaw(uint16_t &x, uint16_t &y);
+    void rotateRaw(int16_t &x, int16_t &y);
     void rotateCal(uint16_t &x, uint16_t &y);
     
     uint8_t csPin, tirqPin, rotation = 1;
-    int16_t xraw = 0, yraw = 0, zraw = 0, _width = 0, _height = 0;
+    int16_t xraw = 0, yraw = 0, zraw = 0;
+    uint16_t _width = 0, _height = 0;
     uint32_t msraw = 0x80000000;
 
     int32_t _cal_dx = 0, _cal_dy = 0, _cal_dvi = 0, _cal_dvj = 0;

--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -1,64 +1,114 @@
 /* Touchscreen library for XPT2046 Touch Controller Chip
- * Copyright (c) 2015, Paul Stoffregen, paul@pjrc.com
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice, development funding notice, and this permission
- * notice shall be included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+   Copyright (c) 2015, Paul Stoffregen, paul@pjrc.com
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice, development funding notice, and this permission
+   notice shall be included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
 
 #ifndef _XPT2046_Touchscreen_h_
 #define _XPT2046_Touchscreen_h_
 
 #include "Arduino.h"
 #include <SPI.h>
+#include <EEPROM.h>
+
+// On my display driver ICs i,j mapped to (width-y),x
+// Flipping can be handled by order of calibration points, but not swapping
+#if !defined(SWAP_AXES)
+#  define SWAP_AXES 1
+#endif
 
 #if ARDUINO < 10600
 #error "Arduino 1.6.0 or later (SPI library) is required"
 #endif
 
+class TS_Calibration {
+  public:
+    TS_Calibration(void)
+      : vi1(0), vj1(0), vi2(0), vj2(0) {}
+
+    TS_Calibration(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2)
+      : vi1(x1), vj1(y1), vi2(x2), vj2(y2) {}
+
+    uint16_t vi1, vj1, vi2, vj2;
+};
+
 class TS_Point {
-public:
-	TS_Point(void) : x(0), y(0), z(0) {}
-	TS_Point(int16_t x, int16_t y, int16_t z) : x(x), y(y), z(z) {}
-	bool operator==(TS_Point p) { return ((p.x == x) && (p.y == y) && (p.z == z)); }
-	bool operator!=(TS_Point p) { return ((p.x != x) || (p.y != y) || (p.z != z)); }
-	int16_t x, y, z;
+  public:
+    TS_Point(void) : x(0), y(0), z(0) {}
+    TS_Point(int16_t x, int16_t y, int16_t z) : x(x), y(y), z(z) {}
+    bool operator==(TS_Point p) {
+      return ((p.x == x) && (p.y == y) && (p.z == z));
+    }
+    bool operator!=(TS_Point p) {
+      return ((p.x != x) || (p.y != y) || (p.z != z));
+    }
+    int16_t x, y, z;
 };
 
 class XPT2046_Touchscreen {
-public:
-	constexpr XPT2046_Touchscreen(uint8_t cspin, uint8_t tirq=255)
-		: csPin(cspin), tirqPin(tirq) { }
-	bool begin();
-	TS_Point getPoint();
-	bool tirqTouched();
-	bool touched();
-	void readData(uint16_t *x, uint16_t *y, uint8_t *z);
-	bool bufferEmpty();
-	uint8_t bufferSize() { return 1; }
-	void setRotation(uint8_t n) { rotation = n % 4; }
-// protected:
-	volatile bool isrWake=true;
+  public:
+    uint16_t CAL_OFFSET = 20;
 
-private:
-	void update();
-	uint8_t csPin, tirqPin, rotation=1;
-	int16_t xraw=0, yraw=0, zraw=0;
-	uint32_t msraw=0x80000000;
+    constexpr XPT2046_Touchscreen(uint8_t cspin, uint8_t tirq = 255)
+      : csPin(cspin), tirqPin(tirq) { }
+    bool begin(uint16_t width = 0, uint16_t height = 0, TS_Calibration cal = TS_Calibration());
+    TS_Point getPoint();
+    TS_Point getPixel();
+    bool tirqTouched();
+    bool touched();
+    void readData(uint16_t *x, uint16_t *y, uint8_t *z);
+    bool bufferEmpty();
+    uint8_t bufferSize() {
+      return 1;
+    }
+    void setRotation(uint8_t n) {
+      rotation = n % 4;
+    }
+    void setWidth(uint16_t width){
+      _width = width;
+    }
+    void setHeight(uint16_t height){
+      _height = height;
+    }
+
+    void getCalibrationPoints(uint16_t &x1, uint16_t &y1, uint16_t &x2, uint16_t &y2);
+    void setCalibration(TS_Calibration cal);
+    TS_Calibration getCalibrationObject(uint16_t vi1, uint16_t vj1, uint16_t vi2, uint16_t vj2) {
+      return TS_Calibration(vi1, vj1, vi2, vj2);
+    }
+
+    void saveCalibrationToEEPROM(TS_Calibration &cal, unsigned int eepromSlot = 0);
+    TS_Calibration getEEPROMCalibration(unsigned int eepromSlot = 0);
+
+    // protected:
+    volatile bool isrWake = true;
+
+  private:
+    void update();
+    void rotate(uint16_t &x, uint16_t &y);
+    
+    uint8_t csPin, tirqPin, rotation = 1;
+    int16_t xraw = 0, yraw = 0, zraw = 0, _width = 0, _height = 0;
+    uint32_t msraw = 0x80000000;
+
+    int32_t _cal_dx = 0, _cal_dy = 0, _cal_dvi = 0, _cal_dvj = 0;
+    uint16_t _cal_vi1 = 0, _cal_vj1 = 0;
 };
 
 #endif

--- a/examples/Calibration/Calibration.ino
+++ b/examples/Calibration/Calibration.ino
@@ -1,0 +1,131 @@
+/*
+   Copyright (c) 2017 Timo Meyer
+*/
+
+#include "XPT2046_Touchscreen.h"
+#include <ILI9341_t3.h>
+
+// Modify the following lines to match your hardware
+#define TFT_DC   15
+#define TFT_CS   10
+#define TFT_RST  4
+//#define TFT_MOSI 11
+//#define TFT_MISO 12
+//#define TFT_CLK  13
+
+//Some Displays need an extra Pin for the LED-Backlight. I used a I/O-Pin also to dim the Backlight.
+#define TFT_LED  19
+
+//And also the Touch-Pins for the XPT2046
+#define TOUCH_CS  20
+#define TOUCH_IRQ 21
+
+#define BLACK   0x0000
+#define WHITE   0xFFFF
+
+ILI9341_t3 display = ILI9341_t3(TFT_CS, TFT_DC, TFT_RST);
+//ILI9341_t3 display = ILI9341_t3(TFT_CS, TFT_DC, TFT_RST, TFT_MOSI, TFT_CLK, TFT_MISO);
+
+XPT2046_Touchscreen touch(TOUCH_CS, TOUCH_IRQ);
+
+void setup() {
+  //Activate backlight
+  pinMode(TFT_LED, OUTPUT);
+  digitalWrite(TFT_LED, HIGH);
+
+  delay(1000);
+
+  //Start display and touch
+  display.begin();
+  touch.begin(display.width(), display.height());
+
+  //Draw background
+  display.fillScreen(BLACK);
+
+  //Calibrate
+  calibrate();  // No rotation!!
+
+  //Clear Screen
+  display.fillScreen(BLACK);
+}
+
+
+void loop() {
+  //If touched than draw
+  if (touch.touched()) {
+    //Get touched and calibrated position
+    TS_Point p = touch.getPixel();
+
+    display.fillCircle(p.x, p.y, 2, WHITE);
+  }
+}
+
+//------------------------------------------------------------------------
+
+void calibrate() {
+  uint16_t x1, y1, x2, y2;
+  uint16_t vi1, vj1, vi2, vj2;
+
+  //Get calibration-Points
+  touch.getCalibrationPoints(x1, y1, x2, y2);
+  //Draw and get RAW-Refference
+  calibratePoint(x1, y1, vi1, vj1);
+  delay(1000);
+
+  //The same again but with new points
+  calibratePoint(x2, y2, vi2, vj2);
+
+  TS_Calibration newCalibration = TS_Calibration(vi1, vj1, vi2, vj2);
+  touch.setCalibration(newCalibration);
+
+  //Write results into a buffer
+  char buf[80];
+  snprintf(buf, sizeof(buf), "%d,%d,%d,%d", (int)vi1, (int)vj1, (int)vi2, (int)vj2);
+
+  //Print it to the Display
+  display.setCursor(0, 25);
+  display.setTextColor(WHITE);
+  display.print("setCalibration params:");
+
+  display.setCursor(0, 50);
+  display.print(buf);
+
+  display.setCursor(0, 75);
+  display.print("Writing to EEPROM...");
+
+  //Save to EEPROM
+  touch.saveCalibrationToEEPROM(newCalibration);
+
+  display.setCursor(0, 100);
+  display.print("Finish!");
+
+  display.setCursor(0, 125);
+  display.print("Start drawing");
+
+  delay(3000);
+}
+
+//------------------------------------------------------------------------
+
+static void calibratePoint(uint16_t x, uint16_t y, uint16_t &vi, uint16_t &vj) {
+  // Draw cross
+  display.drawFastHLine(x - 8, y, 17, WHITE);
+  display.drawFastVLine(x, y - 8, 17, WHITE);
+  display.drawCircle(x, y, 8, WHITE);
+
+  //Wait until touched
+  while (!touch.touched()) {
+    delay(10);
+  }
+
+  //Get uncallibrated Raw touchpoint
+  TS_Point p = touch.getPoint();
+
+  vi = p.x;
+  vj = p.y;
+
+  // Erase by overwriting with black
+  display.drawFastHLine(x - 8, y, 17, BLACK);
+  display.drawFastVLine(x, y - 8, 17, BLACK);
+  display.drawCircle(x, y, 8, BLACK);
+}

--- a/examples/DrawWithCalibration/DrawWithCalibration.ino
+++ b/examples/DrawWithCalibration/DrawWithCalibration.ino
@@ -1,0 +1,50 @@
+#include "XPT2046_Touchscreen.h"
+#include <ILI9341_t3.h>
+
+// Modify the following lines to match your hardware
+#define TFT_DC   15
+#define TFT_CS   10
+#define TFT_RST  4
+//#define TFT_MOSI 11
+//#define TFT_MISO 12
+//#define TFT_CLK  13
+
+//Some Displays need an extra Pin for the LED-Backlight. I used a I/O-Pin also to dim the Backlight.
+#define TFT_LED  19
+
+//And also the Touch-Pins for the XPT2046
+#define TOUCH_CS  20
+#define TOUCH_IRQ 21
+
+#define BLACK   0x0000
+#define WHITE   0xFFFF
+
+ILI9341_t3 display = ILI9341_t3(TFT_CS, TFT_DC, TFT_RST);
+//ILI9341_t3 display = ILI9341_t3(TFT_CS, TFT_DC, TFT_RST, TFT_MOSI, TFT_CLK, TFT_MISO);
+
+XPT2046_Touchscreen touch(TOUCH_CS, TOUCH_IRQ);
+
+void setup() {
+  //Activate backlight
+  pinMode(TFT_LED, OUTPUT);
+  digitalWrite(TFT_LED, HIGH);
+
+  delay(1000);
+
+  //Start display and touch
+  display.begin();
+  touch.begin(display.width(), display.height(), touch.getEEPROMCalibration());
+
+  //Draw background
+  display.fillScreen(BLACK);
+}
+
+void loop() {
+  //If touched than draw
+  if (touch.touched()) {
+    //Get touched and calibrated position
+    TS_Point p = touch.getPixel();
+
+    display.fillCircle(p.x, p.y, 2, WHITE);
+  }
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,8 +1,16 @@
 XPT2046_Touchscreen	KEYWORD1
 TS_Point	KEYWORD1
+TS_Calibration	KEYWORD1
 getPoint	KEYWORD2
 touched	KEYWORD2
 readData	KEYWORD2
 bufferEmpty	KEYWORD2
 bufferSize	KEYWORD2
 setRotation	KEYWORD2
+getPixel	KEYWORD2
+setWidth	KEYWORD2
+setHeight	KEYWORD2
+getCalibrationPoints	KEYWORD2
+setCalibration	KEYWORD2
+getCalibrationObject	KEYWORD2
+saveCalibrationToEEPROM	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -14,3 +14,4 @@ getCalibrationPoints	KEYWORD2
 setCalibration	KEYWORD2
 getCalibrationObject	KEYWORD2
 saveCalibrationToEEPROM	KEYWORD2
+getEEPROMCalibration	KEYWORD2


### PR DESCRIPTION
I have added a method to calibrate/map the raw data to the actual pixels on screen. With an example scetch, you can calibrate the display and automatically save the calibration to EEPROM to reuse it in a different scetch. You can still use the library like before without any changes to get raw data.

Please have a look at the diffs.