### PR TITLE
TouchTest example to use polling instead of interrupt

### DIFF
--- a/examples/TouchTest/TouchTest.ino
+++ b/examples/TouchTest/TouchTest.ino
@@ -4,11 +4,10 @@
 #define CS_PIN  8
 // MOSI=11, MISO=12, SCK=13
 
-//XPT2046_Touchscreen ts(CS_PIN);
 #define TIRQ_PIN  2
-//XPT2046_Touchscreen ts(CS_PIN);  // Param 2 - NULL - No interrupts
+XPT2046_Touchscreen ts(CS_PIN);  // Param 2 - NULL - No interrupts
 //XPT2046_Touchscreen ts(CS_PIN, 255);  // Param 2 - 255 - No interrupts
-XPT2046_Touchscreen ts(CS_PIN, TIRQ_PIN);  // Param 2 - Touch IRQ Pin - interrupt enabled polling
+//XPT2046_Touchscreen ts(CS_PIN, TIRQ_PIN);  // Param 2 - Touch IRQ Pin - interrupt enabled polling
 
 void setup() {
   Serial.begin(38400);


### PR DESCRIPTION
First off, great work on the library Paul!

### Change
- Modified the default constructor in `TouchTest.ino` to use polling mode

### Description
- `TouchTestIRQ.ino` demonstrates the use of the interrupt event APIs
- I believe `TouchTest.ino` was originally intended to demonstrate the use of the polling APIs
- However, the current `TouchTest.ino` invokes the `TIRQ_PIN` constructor (`!=255`) which appears to initiate the ISR handling mode
- The existing default may potentially introduce confusion for some users, hence the proposal to adjust the constructor mode

thanks