### PR TITLE
Fixes buildability with Arduino Core 2.5.1

### DIFF
--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -46,7 +46,7 @@ bool XPT2046_Touchscreen::begin()
 #ifdef ESP32
 void IRAM_ATTR isrPin( void )
 #else
-void isrPin( void )
+void ICACHE_RAM_ATTR isrPin( void )
 #endif
 {
 	XPT2046_Touchscreen *o = isrPinptr;


### PR DESCRIPTION
Added ICACHE_RAM_ATTR to the isrPin otherwise Arduino core complains "ISR not in IRAM" in extern void ICACHE_RAM_ATTR __attachInterruptArg(uint8_t pin, voidFuncPtr userFunc, void *arg, int mode) in cores/esp8266/core_esp8266_wiring_digital.cpp