### PR TITLE
Fix API parameter types for readData()

### DIFF
--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -67,7 +67,7 @@ bool XPT2046_Touchscreen::touched()
 	return (zraw >= Z_THRESHOLD);
 }
 
-void XPT2046_Touchscreen::readData(uint16_t *x, uint16_t *y, uint8_t *z)
+void XPT2046_Touchscreen::readData(int16_t *x, int16_t *y, int16_t *z)
 {
 	update();
 	*x = xraw;

--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -47,7 +47,7 @@ public:
 	TS_Point getPoint();
 	bool tirqTouched();
 	bool touched();
-	void readData(uint16_t *x, uint16_t *y, uint8_t *z);
+	void readData(int16_t *x, int16_t *y, int16_t *z);
 	bool bufferEmpty();
 	uint8_t bufferSize() { return 1; }
 	void setRotation(uint8_t n) { rotation = n % 4; }


### PR DESCRIPTION
The existing `readData()` API has mismatched integer type widths, preventing the user from using the API to query the `z` (pressure) value.

This simple fix adjusts the API parameters to match the returned data types.

**Existing API**:
```c++
void XPT2046_Touchscreen::readData(uint16_t *x, uint16_t *y, uint8_t *z)
{
	update();
	*x = xraw;
	*y = yraw;
	*z = zraw;
}
```

**Raw value declarations**:
```c++
private:
	int16_t xraw=0, yraw=0, zraw=0;
```

Thanks