### PR TITLE
Allow use to choose a different SPI port and also ability to use my F…

### DIFF
--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -26,6 +26,12 @@
 #include "Arduino.h"
 #include <SPI.h>
 
+#if defined(__IMXRT1062__)
+#if __has_include(<FlexIOSPI.h>)
+	#include <FlexIOSPI.h>
+#endif
+#endif
+
 #if ARDUINO < 10600
 #error "Arduino 1.6.0 or later (SPI library) is required"
 #endif
@@ -43,7 +49,11 @@ class XPT2046_Touchscreen {
 public:
 	constexpr XPT2046_Touchscreen(uint8_t cspin, uint8_t tirq=255)
 		: csPin(cspin), tirqPin(tirq) { }
-	bool begin();
+	bool begin(SPIClass &wspi = SPI);
+#if defined(_FLEXIO_SPI_H_)
+	bool begin(FlexIOSPI &wflexspi);
+#endif
+
 	TS_Point getPoint();
 	bool tirqTouched();
 	bool touched();
@@ -59,6 +69,10 @@ private:
 	uint8_t csPin, tirqPin, rotation=1;
 	int16_t xraw=0, yraw=0, zraw=0;
 	uint32_t msraw=0x80000000;
+	SPIClass *_pspi = nullptr;
+#if defined(_FLEXIO_SPI_H_)
+	FlexIOSPI *_pflexspi = nullptr;
+#endif
 };
 
 #ifndef ISR_PREFIX


### PR DESCRIPTION
…lexSPI code

Added the ability to specify a different SPI port on the begin method.
like
```
ts.begin(&SPI1);
```
And use SPI1 for the touch screen.

Also for T4.x as an experiment I added support to allow you to include my FlexIO library including the FlexSPI object :
My library is up at: https://github.com/KurtE/FlexIO_t4

I experimented with my version of Touchpaint_xpt2046;, with using different pins for the touch SPI pins than the display..
On T4.1 I tried using SPI1, with pins that would work for either SPI1 or FlexIO.

For FlexIO I could do:
```
#define Touch_SCK    27  // B0_10
#define Touch_CS     38  // B1_01
#define Touch_MOSI  26  // B1_00
#define Touch_MISO  39  // B0_11S
FlexIOSPI SPIFLEX(Touch_MOSI, Touch_MISO, Touch_SCK, -1); // Setup on (int mosiPin, int sckPin, int misoPin, int csPin=-1) :
XPT2046_Touchscreen ts(Touch_CS);
```
And later I would do:
```
ts.begin(&SPIFLEX);
```

Or since these are actually SPI1 bpins. could use the defines like before:
```
#define Touch_SCK    27  // B0_10
#define Touch_CS     38  // B1_01
#define Touch_MOSI  26  // B1_00
#define Touch_MISO  39  // B0_11S
XPT2046_Touchscreen ts(Touch_CS);
```

And then in setup do:
```
  SPI1.setMISO(Touch_MISO);
  if (!ts.begin(&SPI1)) {
```

Which appeared to work.

I tried adding the use of my flexIO library with the syntax like:
```
#if defined(__IMXRT1062__)
#if __has_include(<FlexIOSPI.h>)
	#include <FlexIOSPI.h>
#endif
#endif
'''
So hopefully should not impact non T4 boards nor ones that don't have my libraries.