### PR TITLE
Added ADCs readings (VBat, AuxIn, Temp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ or with getPoint(), which returns a TS_Point object:
 
 The Z coordinate represents the amount of pressure applied to the screen.
 
+## Reading ADCs Info
+
+The XPT2046 is loaded with a VBat input with an internal voltage divider 1:4, so you can input 0.125V to 6V without issues. 
+There's also a AuxIn you can input 0.125V to 1.5V.
+Finally, there's also an ambient temperature sensor. The resolution is 1.6°C per bit and fluctuates a lot (+/- 3°C), but gives a general idea.
+
+Using the following commands, you can access those values:
+
+      Serial.println(ts.getVBat());
+      Serial.println(ts.getAuxIn());
+      Serial.println(ts.getTemp());
+      Serial.println(ts.getTempF());
+
 ## Adafruit Library Compatibility
 
 XPT2046_Touchscreen is meant to be a compatible with sketches written for Adafruit_STMPE610, offering the same functions, parameters and numerical ranges as Adafruit's library.

--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ The Z coordinate represents the amount of pressure applied to the screen.
 
 ## Reading ADCs Info
 
-The XPT2046 is loaded with a VBat input with an internal voltage divider 1:4, so you can input 0.125V to 6V without issues. 
-There's also a AuxIn you can input 0.125V to 1.5V.
-Finally, there's also an ambient temperature sensor. The resolution is 1.6°C per bit and fluctuates a lot (+/- 3°C), but gives a general idea.
+The XPT2046 is loaded with different ADC inputs thats can be read
+ - VBat input with an internal voltage divider 1:4, so you can input 0.125V to 6V without issues. 
+ - AuxIn you can input 0.125V to 1.5V
+ - Temp/Temp0 are used for ambient temperature. The resolution is 1.6°C per bit and fluctuates a lot (+/- 3°C), but gives a general idea.
 
-Using the following commands, you can access those values:
+Using the following functions, you can read the ADCs and they'll return a float:
 
       Serial.println(ts.getVBat());
       Serial.println(ts.getAuxIn());

--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -238,12 +238,11 @@ int16_t XPT2046_Touchscreen::updateADC(int16_t adc)
             data[0] = data[1] - data[0];
         }
         
-        SPI.transfer16(adc_address[adc]-7);	// dummy measure power down
-        SPI.transfer16(0);
+        _pspi->transfer16(adc_address[adc]-7);	// dummy measure power down
+        _pspi->transfer16(0);
 
         digitalWrite(csPin, HIGH);
-        SPI.endTransaction();
-        
+        _pspi->endTransaction();
     }
 #if defined(_FLEXIO_SPI_H_)
 	else if (_pflexspi) {
@@ -256,11 +255,11 @@ int16_t XPT2046_Touchscreen::updateADC(int16_t adc)
             _pflexspi->transfer16(adc_address[adc+1]);  // dummy measure, 1st is always noisy
             data[1] = _pflexspi->transfer16(adc_address[adc+1]) >> 3;
             
-            data[0] = data[1] - data[0];
+            data[0] = data[1] - data[0]; //Calclate differential between both readings
         }
         
-        SPI.transfer16(adc_address[adc]-7);	// dummy measure power down
-        SPI.transfer16(0);
+        _pflexspi->transfer16(adc_address[adc]-7);	// dummy measure power down
+        _pflexspi->transfer16(0);
         
         digitalWrite(csPin, HIGH);
 		_pflexspi->endTransaction();
@@ -268,7 +267,6 @@ int16_t XPT2046_Touchscreen::updateADC(int16_t adc)
 #endif
     
     return data[0];
-
 }
 
 float XPT2046_Touchscreen::getVBat()

--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -61,11 +61,16 @@ public:
 	bool bufferEmpty();
 	uint8_t bufferSize() { return 1; }
 	void setRotation(uint8_t n) { rotation = n % 4; }
+    float getVBat();
+    float getAuxIn();
+    float getTemp();
+    float getTempF();
 // protected:
 	volatile bool isrWake=true;
 
 private:
 	void update();
+    int16_t updateADC(int16_t adc);
 	uint8_t csPin, tirqPin, rotation=1;
 	int16_t xraw=0, yraw=0, zraw=0;
 	uint32_t msraw=0x80000000;

--- a/examples/AdcTests/AdcTests.ino
+++ b/examples/AdcTests/AdcTests.ino
@@ -1,0 +1,27 @@
+#include <XPT2046_Touchscreen.h>
+#include <SPI.h>
+
+#define CS_PIN  8
+// MOSI=11, MISO=12, SCK=13
+
+//XPT2046_Touchscreen ts(CS_PIN);
+#define TIRQ_PIN  2
+//XPT2046_Touchscreen ts(CS_PIN);  // Param 2 - NULL - No interrupts
+//XPT2046_Touchscreen ts(CS_PIN, 255);  // Param 2 - 255 - No interrupts
+XPT2046_Touchscreen ts(CS_PIN, TIRQ_PIN);  // Param 2 - Touch IRQ Pin - interrupt enabled polling
+
+void setup() {
+  Serial.begin(38400);
+  ts.begin();
+  while (!Serial && (millis() <= 1000));
+}
+
+void loop() {
+  Serial.println(ts.getVBat());
+  Serial.println(ts.getAuxIn());
+  Serial.println(ts.getTemp());
+  Serial.println(ts.getTempF()); //This value is not taken at the same time, therefor value might not fit the Celsius value
+  Serial.println();
+
+  delay(1000);
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -5,7 +5,7 @@ getVBat		KEYWORD2
 getAuxIn	KEYWORD2
 getTemp		KEYWORD2
 getTempF	KEYWORD2
-touched	KEYWORD2
+touched	  KEYWORD2
 readData	KEYWORD2
 bufferEmpty	KEYWORD2
 bufferSize	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,6 +1,10 @@
 XPT2046_Touchscreen	KEYWORD1
 TS_Point	KEYWORD1
 getPoint	KEYWORD2
+getVBat		KEYWORD2
+getAuxIn	KEYWORD2
+getTemp		KEYWORD2
+getTempF	KEYWORD2
 touched	KEYWORD2
 readData	KEYWORD2
 bufferEmpty	KEYWORD2


### PR DESCRIPTION
I added the required functions to access the internal ADCs (VBat, AuxIn, Temp) from XPT2046. Been tested on my previously working circuit, so the original features still work as expected with addition of new features