### PR TITLE
Decrease Z_THRESHOLD by 100, so that the far corner of panel becomes reliable.

### DIFF
--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -22,7 +22,7 @@
 
 #include "XPT2046_Touchscreen.h"
 
-#define Z_THRESHOLD     400
+#define Z_THRESHOLD     300
 #define Z_THRESHOLD_INT	75
 #define MSEC_THRESHOLD  3
 #define SPI_SETTING     SPISettings(2000000, MSBFIRST, SPI_MODE0)


### PR DESCRIPTION
Far corner of the touch panel on nearly all of the panels I own (I have several) won't detect a touch event. 
The problem stems from the fact that there isn't enough flexibility at the corners of the digitizer near the edges. 
If you compare to the IRQ pin, this trips MUCH earlier, however noise could cause false tripping, and a higher threshold is a good idea. 
By increasing the sensitivity a little bit, two things are also gained as a side effect:

1. Less pressure is required to detect a touch.
2. Less wear on a resistivity screen is a good thing.
